### PR TITLE
Give index.js a shebang line to imply node interpreter

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 'use strict';
 
 require('./bootstrap');


### PR DESCRIPTION
Without this, the script file is parsed as a bash script, resulting in syntax
errors.